### PR TITLE
Add support for automatic deployment when push to master

### DIFF
--- a/deployment/templates/deploymentconfig.yaml
+++ b/deployment/templates/deploymentconfig.yaml
@@ -26,7 +26,11 @@ spec:
         deploymentconfig: {{ .Values.name }}
     spec:
       containers:
-      - image: "{{ .Values.imageName }}:{{ .Values.imageTag }}"
+      {{- if eq .Values.imageTag "latest" }}
+      - image: {{ .Values.name }}:{{ .Values.imageTag }}
+      {{- else }}
+      - image: {{ .Values.imageName }}:{{ .Values.imageTag }}
+      {{- end }}
         imagePullPolicy: Always
         name: {{ .Values.name }}
         ports:
@@ -49,3 +53,13 @@ spec:
           name: frontend-config
   triggers: 
   - type: ConfigChange
+  {{- if eq .Values.imageTag "latest" }}
+  - type: ImageChange
+    imageChangeParams:
+      automatic: true
+      from:
+        kind: ImageStreamTag
+        name: {{ .Values.name }}:{{ .Values.imageTag }}
+      containerNames:
+      - {{ .Values.name }}
+  {{- end }}

--- a/deployment/templates/imagestream.yaml
+++ b/deployment/templates/imagestream.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.imageTag "latest" }}
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: {{ .Values.name }}
+  name: {{ .Values.name }}
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: {{ .Values.imageName }}:{{ .Values.imageTag }}
+    importPolicy:
+      scheduled: true
+    name: {{ .Values.imageTag }}
+    referencePolicy:
+      type: Source
+{{- end }}


### PR DESCRIPTION
If we're set to track the `:latest` tag, create and use an ImageStream to trigger new deployments.