### PR TITLE
Reject users without access privileges

### DIFF
--- a/src/components/authentication/private_route.tsx
+++ b/src/components/authentication/private_route.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Route, RouteProps } from 'react-router-dom';
+import { Redirect, Route, RouteProps } from 'react-router-dom'
 import { SendToSSO } from './send_to_sso';
 import { SessionContext } from '../../context/session_context';
 
@@ -15,7 +15,9 @@ export const PrivateRoute = ({
   const sessionContext = useContext(SessionContext);
 
   if (sessionContext.authState === 'authenticated') {
-    return <Route {...rest} render={props => <Component {...props} />} />;
+    return <Route {...rest} render={props => <Component {...props} />}/>;
+  } else if (sessionContext.authState === 'unauthorized') {
+    return <Redirect to="/unauthorized" />
   } else if (sessionContext.authState === 'unauthenticated') {
     return <SendToSSO />;
   } else {

--- a/src/context/session_context.tsx
+++ b/src/context/session_context.tsx
@@ -103,7 +103,6 @@ export const SessionProvider = ({
               tokens,
               roles: profile.groups,
             });
-            console.log("groups:", profile.groups);
             if(profile.groups ? profile.groups.includes('manage_projects') : false){
               setAuthStatus('authenticated');
             }else{

--- a/src/context/session_context.tsx
+++ b/src/context/session_context.tsx
@@ -17,7 +17,8 @@ import { Request } from '../utilities/request';
 export type AuthenticationState =
   | 'initial'
   | 'authenticated'
-  | 'unauthenticated';
+  | 'unauthenticated'
+  | 'unauthorized';
 
 export interface SessionData {
   profile?: UserProfile;
@@ -95,13 +96,18 @@ export const SessionProvider = ({
       authenticationRepository.isLoggedIn().then(isLoggedIn => {
         const tokens = authenticationRepository.getToken();
         if (isLoggedIn && tokens) {
-          setAuthStatus('authenticated');
+
           authenticationRepository.getUserProfile().then(profile => {
             setSessionData({
               profile,
               tokens,
               roles: profile.groups,
             });
+            if(profile.groups?.includes('manage_projects')){
+              setAuthStatus('authenticated');
+            }else{
+              setAuthStatus('unauthorized')
+            }
           });
         } else {
           setAuthStatus('unauthenticated');

--- a/src/context/session_context.tsx
+++ b/src/context/session_context.tsx
@@ -103,7 +103,8 @@ export const SessionProvider = ({
               tokens,
               roles: profile.groups,
             });
-            if(profile.groups?.includes('manage_projects')){
+            console.log("groups:", profile.groups);
+            if(profile.groups ? profile.groups.includes('manage_projects') : false){
               setAuthStatus('authenticated');
             }else{
               setAuthStatus('unauthorized')

--- a/src/routes/logout/index.tsx
+++ b/src/routes/logout/index.tsx
@@ -8,7 +8,8 @@ class LogoutPage extends React.Component<{}, { session: SessionContext }> {
     session.logout().then(
       // not my favorite solution... but SSO seems to need a second after /logout is hit before it actually "takes"...
       setTimeout(() => {
-        window.location.reload();
+        // retrigger forward to SSO
+        window.location.href = "/";
       }, 500)
     );
   }

--- a/src/routes/logout/index.tsx
+++ b/src/routes/logout/index.tsx
@@ -19,7 +19,7 @@ class LogoutPage extends React.Component<{}, { session: SessionContext }> {
   }
 }
 
-export default React.forwardRef(props => (
+export default React.forwardRef((props, ref) => (
   <SessionContext.Consumer>
     {session => <LogoutPage {...props} session={session} />}
   </SessionContext.Consumer>

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -12,6 +12,7 @@ import { EngagementPane } from './engagement_pane';
 import { Admin } from './admin';
 import { Dashboard } from './dashboard';
 import { EngagementFormProvider } from '../context/engagement_form_context';
+import { UnauthorizedPage } from './unauthorized';
 import LogoutPage from './logout'
 
 function _OMPRouter() {
@@ -47,10 +48,11 @@ function _OMPRouter() {
           );
         }}
       />
-      <Route path="/feature-request" component={FeatureRequest} />
       <PrivateRoute path="/private" component={() => <Redirect to="/" />} />
-      <Route path="/auth_callback" component={CallbackHandler} />
       <PrivateRoute path="/logout" component={() => <LogoutPage />} />
+      <Route path="/feature-request" component={FeatureRequest} />
+      <Route path="/auth_callback" component={CallbackHandler} />
+      <Route path="/unauthorized" component={UnauthorizedPage} />
     </Switch>
   );
 }

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -49,7 +49,7 @@ function _OMPRouter() {
         }}
       />
       <PrivateRoute path="/private" component={() => <Redirect to="/" />} />
-      <PrivateRoute path="/logout" component={() => <LogoutPage />} />
+      <Route path="/logout" component={() => <LogoutPage />} />
       <Route path="/feature-request" component={FeatureRequest} />
       <Route path="/auth_callback" component={CallbackHandler} />
       <Route path="/unauthorized" component={UnauthorizedPage} />

--- a/src/routes/unauthorized/index.tsx
+++ b/src/routes/unauthorized/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export function UnauthorizedPage() {
+  const contentPane: React.CSSProperties = {
+    backgroundColor: '#EDEDED',
+    height: '100vh',
+    padding: 15,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
+  return (
+    <>
+      <div style={contentPane}>
+        <p>Sorry, your account has not yet been given access to OMP. Please contact the SRE team to resolve this.</p>
+      </div>
+    </>
+  );
+}

--- a/src/routes/unauthorized/index.tsx
+++ b/src/routes/unauthorized/index.tsx
@@ -13,7 +13,7 @@ export function UnauthorizedPage() {
   return (
     <>
       <div style={contentPane}>
-        <p>Sorry, your account has not yet been given access to OMP. Please contact the SRE team to resolve this.</p>
+        <p>Sorry, your account has not yet been granted access to this system. Please contact the SRE team to resolve this.</p>
       </div>
     </>
   );

--- a/src/services/authentication_service/implementations/apiv1_auth_service.ts
+++ b/src/services/authentication_service/implementations/apiv1_auth_service.ts
@@ -168,6 +168,7 @@ export class Apiv1AuthService implements AuthService {
       firstName: userProfileData.data.given_name,
       lastName: userProfileData.data.family_name,
       email: userProfileData.data.email,
+      groups: userProfileData.data.groups,
     });
   }
 }


### PR DESCRIPTION
If a user authenticates successfully but doesn't have the role `manage_projects`, display an unauthorized page directing them to contact the SREs instead of consistently hitting 401s from the backend and kicking the user out.

NOTE: The role name `manage_projects` goes all the way back to proof-of-concept days, and no longer reflects what it does. I think it should be changed both here and in the backend repo, but leaving that for a future edit unless we want to get it done now.

<img width="1207" alt="Screen Shot 2020-04-25 at 2 50 04 PM" src="https://user-images.githubusercontent.com/5027680/80291691-a5d46300-8704-11ea-950f-045151380438.png">
