### PR TITLE
Always display account switcher when using Google login

### DIFF
--- a/src/components/authentication/send_to_sso.tsx
+++ b/src/components/authentication/send_to_sso.tsx
@@ -16,7 +16,9 @@ export function SendToSSO() {
     OAUTH_CONFIG.clientId
   }&redirect_uri=${encodeURI(
     OAUTH_CONFIG.redirectUri
-  )}&response_type=code&state=${encodeURI(JSON.stringify(OAUTH_CONFIG.state))}`;
+  )}&response_type=code&prompt=select_account&state=${encodeURI(
+    JSON.stringify(OAUTH_CONFIG.state)
+  )}`;
   window.location = (OAUTH_URL as any) as Location;
   return <div />;
 }


### PR DESCRIPTION
Keyclock simply forwards this additional param through to Google SSO, so, adding it here seems to be sufficient!

<img width="471" alt="Screen Shot 2020-04-27 at 2 24 32 PM" src="https://user-images.githubusercontent.com/5027680/80422523-245f0b00-8893-11ea-9b05-4e773c43b8df.png">
